### PR TITLE
Move to a single Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
       config.vm.provision "ansible" do |ansible|
         ansible.playbook = "devstack.yml"
         ansible.raw_arguments = "-vvv"
-        ansible.host_vars = {machine['name'] => {"ansible_ssh_common_args": escape("-o ProxyCommand=\"ssh '#{machine['name']}' -l '#{machine['hypervisor']['username']}' -i '/#{ENV['HOME']}/.ssh/id_rsa' nc %h %p\"")}}
+        ansible.host_vars = {machine['name'] => {"ansible_ssh_common_args": escape("-o ProxyCommand=\"ssh '#{machine['hypervisor']['name']}' -l '#{machine['hypervisor']['username']}' -i '/#{ENV['HOME']}/.ssh/id_rsa' nc %h %p\"")}}
         ansible.extra_vars = {
           local_conf_file: machine['local_conf_file']
         }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+require 'yaml'
+
+def escape(s)
+    "\"" + s.gsub("\\", "\\\\").gsub("\"", "\\\"") + "\""
+end
+
+directory = YAML.load_file("directory.conf.yml")
+
+username = "root"
+
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder '~/vagrant/common', '/vagrant_common', type: "rsync"
+
+  directory['machines'].each do |machine|
+    config.vm.define machine['name'] do |config|
+      config.vm.hostname = machine['name']
+      config.vm.box = machine['box']
+      config.vm.provider :libvirt do |libvirt|
+        libvirt.host = machine['hypervisor']['name']
+        libvirt.connect_via_ssh = true
+        libvirt.username = machine['hypervisor']['username']
+        libvirt.memory = machine['memory']
+        libvirt.cpus = machine['vcpus']
+      end
+      config.vm.provision "ansible" do |ansible|
+        ansible.playbook = "devstack.yml"
+        ansible.raw_arguments = "-vvv"
+        ansible.host_vars = {machine['name'] => {"ansible_ssh_common_args": escape("-o ProxyCommand=\"ssh '#{machine['name']}' -l '#{machine['hypervisor']['username']}' -i '/#{ENV['HOME']}/.ssh/id_rsa' nc %h %p\"")}}
+        ansible.extra_vars = {
+          local_conf_file: machine['local_conf_file']
+        }
+      end
+    end
+  end
+end

--- a/devstack.yml
+++ b/devstack.yml
@@ -1,4 +1,4 @@
-- hosts: default
+- hosts: all
   gather_facts: no
 - include: playbooks/ansible-setup.yml
 - include: playbooks/development.yml

--- a/directory.conf.yml
+++ b/directory.conf.yml
@@ -1,0 +1,9 @@
+machines:
+  - name: one
+    hypervisor:
+      name: localhost
+      username: root
+    memory: 8192
+    vcpus: 1
+    box: "fedora/23-cloud-base"
+    local_conf_file: ../common/local.confs/local.conf.standalone.zmq.df_l3_agent.ml2

--- a/playbooks/acl.yml
+++ b/playbooks/acl.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Install acl
     package: name=acl state=present

--- a/playbooks/ansible-setup.yml
+++ b/playbooks/ansible-setup.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   gather_facts: no
   tasks:
   - name: Install dependencies

--- a/playbooks/development.yml
+++ b/playbooks/development.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Update system packages
     dnf: name=* state=latest

--- a/playbooks/devstack.yml
+++ b/playbooks/devstack.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Clone devstack
     git: dest=/home/stack/devstack repo=https://github.com/openstack-dev/devstack
@@ -8,7 +8,7 @@
     tags:
     - devstack-only
   - name: Install local.conf
-    shell: cp /vagrant/local.conf devstack/local.conf chdir=/home/stack creates=/home/stack/devstack/local.conf
+    copy: src={{local_conf_file}} dest=/home/stack/devstack/local.conf
     become: yes
     become_user: stack
     tags:

--- a/playbooks/git.yml
+++ b/playbooks/git.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Install git (Debian)
     apt: name=git state=present

--- a/playbooks/python-devel.yml
+++ b/playbooks/python-devel.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
     # - name: Install python-pip (Debian)
     #   apt: name=python-pip state=present

--- a/playbooks/reboot.yml
+++ b/playbooks/reboot.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Restart server
     #command: shutdown -r now "Ansible updates triggered"

--- a/playbooks/stack-user.yml
+++ b/playbooks/stack-user.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Add Stack user
     user: name=stack append=yes groups=wheel

--- a/playbooks/tmux.yml
+++ b/playbooks/tmux.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: all
   tasks:
   - name: Install tmux (Debian)
     apt: name=tmux state=present


### PR DESCRIPTION
Previous implementation used a bash script to generate a Vagrantfile,
and then call vagrant up.

In this patch, we move away from that behaviour. There is a single
Vagrantfile, and a configuration file (directory.conf.yml) that contains
the configuration of all VMs.

To create a new vm, add it to directory.conf.yml. To remove it (after
running vagrant destroy), remove it from that file.
