### PR TITLE
Copy CPU flags from the host CPU

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure(2) do |config|
         libvirt.username = machine['hypervisor']['username']
         libvirt.memory = machine['memory']
         libvirt.cpus = machine['vcpus']
+        libvirt.cpu_mode = 'host-passthrough'
       end
       config.vm.provision "ansible" do |ansible|
         ansible.playbook = "devstack.yml"


### PR DESCRIPTION
This makes sure vagrant won't pick a CPU type incompatible with the one
it is running on.

Signed-off-by: Dima Kuznetsov dima.kuznetsov@huawei.com
