### PR TITLE
Allow installing patches in review from gerrit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,8 @@ Vagrant.configure(2) do |config|
         ansible.raw_arguments = "-vvv"
         ansible.host_vars = {machine['name'] => {"ansible_ssh_common_args": escape("-o ProxyCommand=\"ssh '#{machine['hypervisor']['name']}' -l '#{machine['hypervisor']['username']}' -i '/#{ENV['HOME']}/.ssh/id_rsa' nc %h %p\"")}}
         ansible.extra_vars = {
-          local_conf_file: machine['local_conf_file']
+          local_conf_file: machine['local_conf_file'],
+          projects: machine['projects']
         }
       end
     end

--- a/directory.conf.yml
+++ b/directory.conf.yml
@@ -5,5 +5,9 @@ machines:
       username: root
     memory: 8192
     vcpus: 1
-    box: "fedora/23-cloud-base"
+    box: "fedora/24-cloud-base"
     local_conf_file: ../common/local.confs/local.conf.standalone.zmq.df_l3_agent.ml2
+    projects:
+    - name: dragonflow
+      reviews:
+      - 405576

--- a/playbooks/devstack.yml
+++ b/playbooks/devstack.yml
@@ -30,6 +30,7 @@
     with_subelements:
     - "{{ projects | d([], True) }}"
     - reviews
+    - skip_missing: True
   - name: Install local.conf
     copy: src={{ local_conf_file }} dest=/home/stack/devstack/local.conf
     become: yes

--- a/playbooks/devstack.yml
+++ b/playbooks/devstack.yml
@@ -7,8 +7,31 @@
     become_user: stack
     tags:
     - devstack-only
+  - name: Create stack base folder
+    file: path=/opt/stack state=directory owner=stack group=stack
+    become: yes
+    become_user: root
+    tags:
+    - devstack-only
+  - name: Clone projects
+    git: dest="/opt/stack/{{ item.name }}" repo="{{ item.repo | d("git://github.com/openstack/" + item.name, True) }}"
+    become: yes
+    become_user: stack
+    with_items: "{{ projects | d([], True) }}"
+  - name: Fetch reviews
+    shell: |
+      cd /opt/stack/{{ item.0.name }}
+      git remote add gerrit {{ item.0.gerrit | d('https://review.openstack.org/openstack/' + item.0.name + '.git') }}
+      GERRIT_REF=`git ls-remote gerrit | grep '\/{{ item.1 }}\/' | awk '{print $2}' | sort -n -k 5 -t '/' | tail -1`
+      git fetch gerrit $GERRIT_REF
+      git merge FETCH_HEAD
+    become: yes
+    become_user: stack
+    with_subelements:
+    - "{{ projects | d([], True) }}"
+    - reviews
   - name: Install local.conf
-    copy: src={{local_conf_file}} dest=/home/stack/devstack/local.conf
+    copy: src={{ local_conf_file }} dest=/home/stack/devstack/local.conf
     become: yes
     become_user: stack
     tags:


### PR DESCRIPTION
Allow installing projects and their patches, while still in review, from
the gerrit review system. The default is for openstack gerrit.

See the changes in directory.conf.yml for a usage example.

See the changes in playbooks/devstack.yml for the full scope of the
change, including available options.